### PR TITLE
Extend and structure the introduction

### DIFF
--- a/future_challenges_for_RSEng.tex
+++ b/future_challenges_for_RSEng.tex
@@ -140,18 +140,20 @@ In Germany, a formal call for creating a sustainable environment for research so
 is only a couple of years behind~\cite{Anzt2021},
 while the foundational competencies of a research software engineer have only recently been defined in detail~\cite{Goth2024}. Central RSE units are in the process of being imagined~\cite{Kempf2025-draft},
 while an RSE Master's is in the early stages of design. 
+
 In this opinion paper, we try to imagine the state of our field
 and community in the mid-term future, focusing on future challenges.
 While future projections are common in industry \cite{gartner}, so far there is a projection lacking for the RSEng space.
 We present here the results of a workshop discussion at the
-deRSE25 conference in Karlsruhe\cite{Goth2025EndRSEng}, without
+deRSE25 conference in Karlsruhe\footnote{deRSE25, session ``The End of {RSEng}? Challenges and Risks for {RSEng}'': \url{https://events.hifis.net/event/1741/contributions/14026/}}, without
 claiming to represent the entire deRSE community.
 Nevertheless, by disseminating the discussed ideas,
 we aim to engage the community in creating a future worth living
 and to advance the conversation about how Research Software Engineering should, or could, develop.
 It is already difficult to structure the spectrum of RSE tasks and responsibilities today given the spectrum of research software \cite{hasselbring2024}.
 It is even more challenging to structure the aspects that will become relevant for the RSE community in the future.
-Nevertheless, in order to structure the discussion, we decided to consider
+
+In order to structure the discussion, we decided to consider
 the evolution of the term RSE and its definition,
 the growth and development of the RSE community,
 the impact of automation and generative artificial intelligence in RSE work,

--- a/future_challenges_for_RSEng.tex
+++ b/future_challenges_for_RSEng.tex
@@ -136,6 +136,10 @@ related to research software.
 
 Research Software Engineering is still a developing field,
 with increasing integration into various aspects of research.
+In Germany, a formal call for creating a sustainable environment for research software
+is only a couple of years behind~\cite{Anzt2021},
+while the foundational competencies of a research software engineer have only recently been defined in detail~\cite{Goth2024}. Central RSE units are in the process of being imagined~\cite{Kempf2025-draft},
+while an RSE Master's is in the early stages of design. 
 In this opinion paper, we try to imagine the state of our field
 and community in the mid-term future, focusing on future challenges.
 While future projections are common in industry \cite{gartner}, so far there is a projection lacking for the RSEng space.


### PR DESCRIPTION
This PR touches the introduction and:

- Adds two sentences citing the earlier work, to set the status quo.
- Replaces the reference to the conference with a footnote. Reason: The reference already reads like a proceedings paper, but this is the actual proceedings paper. This duplication could create confusion in future works citing this paper.
- Splits three paragraphs: status quo, towards the future, structure of what follows.

Another PR for Section 2.6 will follow.