### PR TITLE
Add review and rebuttal template

### DIFF
--- a/correspondence/rebuttal-1.md
+++ b/correspondence/rebuttal-1.md
@@ -1,0 +1,201 @@
+# Rebuttal
+
+Manuscript: "Future challenges for Research Software Engineering"
+
+| Reviewer | Recommendation      | Relevance | Significance | Technical soundness | Presentation |
+| ---      | ---                 | ---       | ---          | ---                 | ---          |
+| A        | Resubmit for review | very good | good         | very good           | good         |
+| B        | Decline submission  | good      | excellent    | fair                | poor         |
+| C        | Revisions required  | excellent | very good    | very good           | good         |
+| D        | Revisions required  | excellent | very good    | good                | very good    |
+
+## Reviewer A
+
+### Summary
+
+> The authors provide a report and discussion on future trends in Research Software Engineering, mainly focused on Germany, based on a workshop discussion during the deRSE25 conference. They provide a discussion on 7 topics addressing possible trends, goals that will be achieved and stories of relatable personas as well as an outlook about the role and standing of RSEs in the academic system.
+
+### Relevance
+
+> The paper is written as opinion paper, not as research paper. The topic fits perfectly to the special issue. I suppose the audience interest is mainly focused to the German scientific community. The topics provided in the paper are timely and contribute to an ongoing global discussion. The paper provides a perspective and does not state to provide a global analysis.
+
+### Significance
+
+> The paper adds to a discussion about trends in Research Software Engineering. The discussion is an important aspect as reflection for current challenges. The authors state that the topics are not exhaustive and the content of the topic discussions provide some perspective, however do not allow for an in-depth assessment/analysis.
+
+### Technical soundness
+
+> This criterion is difficult to assess as the paper is an opinion paper. There is no transcript of the workshop the authors base their statements on. Thus, an assessment on the soundness is impossible. The authors include relevant topics that will need attention in the near future.
+
+### Quality of presentation
+
+> Especially the changing tenses make the paper a difficult read. The paper is well structured in 4 sections. The second section as main section includes goal statements and persona stories for each topic, respectively. This makes the topics easier to understand and is thus well structured. The formatting and spelling needs some attention. Regarding readability, I provide suggestions below.
+
+### Suggestions
+
+> 1. The authors do not mention Germany as the focus of their discussion, probably because they want to address a broader aspect of RSEng that could apply to other countries or even globally. However, the history, focus and references clearly indicate a German perspective. I suggest either making it clear that the vision and discussion are limited to Germany, or discussing why the focus of the paper is rather nationalistic yet applies to a broader range of locations, and explaining where and why the stated aspects differ.
+
+> 2. The authors switch between the past and present tenses, which makes reading the article difficult. They sometimes address present tools, infrastructure and activities, and sometimes write as if future tools, infrastructure and activities have been made available or developed. For example, the "Achieved Goals" refer to goals achieved by 2035, but the tenses change throughout the boxes. "RSEng-relevant open educational resources..." Some resources are available and some are not; however, the style of writing makes it difficult to tell the difference. I would propose that the authors use tenses to clearly distinguish between past, present and future activities, tools and resources, and not write as if future activities have already been successful. Additionally, the authors write about their hopes, which seem off-topic for a report or opinion paper. I would suggest not writing about hopes at all. Future trend statements should be based on knowledge.
+
+> 3. The authors claim to "present here the results of a workshop discussion at the deRSE25 conference in Karlsruhe". However, they also include their hopes, discussions and own expectations for the future RSE ecosystem (in Germany). This should be mentioned in the introduction and it should be made clear which statements have been put forward during the discussion and which have been added by the authors after the discussion. The authors mention this construct in section 3 ("In the previous sections, we have tried to list some of the trends that we foresee. The material presented here is based on the outputs of a workshop, but extended with the authors’ ideas."), which makes understanding the paper difficult; I would expect such a statement at the beginning. While I do not propose to re-structure the paper (e.g. report first, discussion second), I suggest to review the paper as to which statements have been reported in the discussion and which statement have been brought up by the authors.
+
+> Regarding Chapter 2.3.
+> I would propose the authors provide a counter argument/discussion to why AI will not totally make RSEs obsolete. Additionally, the authors paint a quite bright picture of the AI future, however not discussing risks to the scientific processes, e.g. difficulty with recplication, societal trust in science, non-democtratization of science because of access to storage, compute and useful data sets, etc.
+
+> Regarding Chaper 2.6
+> "thinking on the time scale of generations". This seems crucial, especially when looking at academia in Germany. Many renowened professors will retire in the next 5-10 years, making way for a younger generation that even may have coded during their career. The authors do not discuss this obvious transformation. Do they no expect at least some RSE professors?
+
+> Minor remarks:
+> Author 12 lacks affiliation information
+
+> Keywords could be richer
+
+> "In order to structure the discussion, we decided to consider...". Was the discussion structured as presented or is the paper structured as presented; the sentence implies the former. Is there a rationale why the authors include the following topics? Have there been other topics in discussion that have not been namend in the paper?
+
+> 2. Chapter
+> This chapter includes the authors vision of the RSE space in 2035.
+
+> "accepted research artefact on an equal footing with data and publications." If software or data is publicized would these artefacts not also be regarded as publications? I would suggest using "data and text" or "data and text publications" instead.
+
+> "The specialist skills that RSEs provide take a significant amount of time to develop and maintain. Therefore, we do not expect domain researchers to also become experts in a range of advanced RSEng topics." Could the authors name some of these advanced topics here? Or maybe change the position of this paragraph to after the paragraph about the domain researchers.
+
+> Story Box 1:
+> "What issues have newly emerged, where they are now just happy to say: .." This seems
+
+> 2.1 Chapter
+>
+> "might remain unchanged, there might be a shift in the responsibilities of RSEs, in the form of a partial reallocation of the training budget to the other core competencies. " What is the rationale for this statement?
+
+> "Looking at that on a broader scale..." What is meant by "that"? What do the authors look at?
+
+> Chapter 2.2
+> "visibility and accelerate the professionalisationof the RSE role" -> missing line spacing
+
+> Story Box 4
+> "Kim accelerates his research.." To my understanding, Kim and Kay are female.
+
+> Chapter 2.5
+> "As engineers, RSEs take the responsibility for the software they develop. RSEs need to be aware of these issues and develop their own “red lines”." This statement underestimates the complexity of how code/knowledge/algorithms can be reused for military purposes. A scientist would need to know about present military technologies which is unrealistic. I fear the call for responsibility is too much to ask from an individual. Additionally, it creates a huge burden if code or a programme has been reused for military purposes. I would suggest that the authors make clear the boundaries of the responsibility.
+
+> Story Box 6:
+> "that are backed by large, foreign corporate entities. So far, she still has the support of the university board, since it values strategic autonomy." This citation shows that the authors seem to write from a German point of view. In the previous sections, international collaboration was highlighted. In a global world, there is no "foreign corporate entity", just collaboration tools from different sources. This is a minor comment here but important for the general remark regarding the perspective given in the paper.
+
+> Chaper 2.7
+> "in lower tiers of an of a research organisation", sentence needs attention
+
+> Story Box 8:
+> "His unique blend of physics knowledge and hands-on problem solving earned him a new title among his peers: the first Quantum RTP. In a world where theory meets reality, Ken quietly ensures that the future of quantum
+> computing stays on track" Is this still a position within the research staff or within the technical staff? The authors seem to imply that HR departements will hire RTPs as research staff. This issue should be discussed.
+
+> Conclusion paragraph. Formatting needs attention.
+
+> Line numbering would make referencing easier
+
+> The reference style in the document looks odd as there is no line spacing between the word and the bracket: ...competencies[WORD]...
+
+\newpage
+
+## Reviewer B
+
+### Summary
+
+> The paper lists a set of expected developments in the future of RSE.
+
+### Relevance
+
+> The paper provides an overview over the challenges and future developments / scenarios
+discussed by the conference participants.
+
+### Significance
+
+> The paper overall is very generic and more related to Software Engineering in general than specific to Research Software. Similar papers on Software Engineering issues already exist and provide more details on the actual challenges, expected development and which technologies and approaches may prove relevant. In most cases, this paper is leaving out concrete issues and already existing developments (see e.g. Intellisoft).
+
+### Technical soundness
+
+> The paper is a bit too generic for an in-depth assessment of its technical soundness. Specifically, many of the "core issues" are mentioned but never listed (with exception of "core software skills" - which ever these may be). As noted under significance, some existing developments in Software Engineering have not been properly respected (AI tooling, standardisation etc.) - which all contributed to the simplicity that allows easy generation of software. RSE has specific additional challenges related to soundness, replicability, reproducibility, interpretability etc. which are not addressed in the paper.
+
+### Quality of presentation
+
+> The paper chooses a very interesting approach to present the key challenges / aspects, with a short description of the aspect leading as a mid- to long-term goal and a "futuristic story" as an exemplary scenario. Most of these aspects relate however to communities recognizing the relevance of RSE much more than what the relevance is, and the futuristic scenarios sometimes do not seem to fit the topic of the goal, such as in the context of Ethics / Social Consideration; few of the scenarios provide additional information that would further the understanding of the challenges or goals.
+
+### Suggestions
+
+> I like the idea and the elaboration of the paper, but fail to see relevant contributions in the individual sections, in particular comes to differentiation from Software Engineering. With that respect, related work in Software Engineering already addresses a lot of aspects mentioned in the paper and should be referenced and acknowledged appropriately as it shapes expectations and future work. I'd love to see a better elaboration of the paper, as again it is a relevant and interesting approach.
+
+\newpage
+
+## Reviewer C
+
+### Summary
+
+> A useful overview of outcomes of a valuable workshop, augmented by the author's own opinions, on the future of RSE.
+
+### Relevance
+
+> This paper reflects on a workshop held at de-RSE
+
+### Significance
+
+> This paper addresses many important themes in this field, and makes useful contributions on how they could be advanced.
+
+### Technical soundness
+
+> This is an opinion paper, based on synthesis of the workshop discussions and the authors' knowledge.
+
+### Quality of presentation
+
+> The use of boxes is a great idea, but doesn't quite work. See the detailed notes for ideas on how to improve this.
+
+### Suggestions
+
+> It might be useful to note that this paper on RSE in 2030 exists https://arxiv.org/pdf/2308.07796, although the workshop participants didn’t know about it so it wasn’t incorporated in their thinking.
+
+> Reviewer C also uploaded a file with more feedback
+
+\newpage
+
+## Reviewer D
+
+### Summary
+
+> This paper is the result of a workshop discussion at the deRSE25 (the 5th conference for Research Software Engineering in Germany, in a workshop session titled "The End of RSEng? Challenges and Risks for RSEng"), and includes views and opinions of participants condensed in a well-structured and readable format by the authors.
+>
+> RSEs (Research Software Engineers) are broadly defined by their core task - "enhancing the scientific output of researchers" - while it is acknowledged that the means by which they currently achieve that end ('RSEng', or 'Research Software Engineering') is likely to evolve towards very different approaches and skillsets in the future, due to the obsoleting and enabling effects of new technologies.
+>
+> The paper mentions the future introduction of a formalised Masters programme for training RSEs as being an important step in the ensuring the continued professionalisation and acceptance of the RSE role in research institutions and beyond, bringing significant efficiency benefits to the research process. It also reiterates the importance of the recognition of research software as an output of a research-focused career, to be taken into consideration for career progression.
+>
+> The paper also highlights what roles for RSEs are likely to stay (mostly) the same, vs change: e.g. educating researchers around the creation and use of software will likely still be a feature, although there will be an increasing emphasis on effective and ethical use of AI-based tools in and through the development of software in research. The availability of AI-based tools is anticipated to increase the scope of what RSEs can achieve, while changing the manner and focus of their work.
+>
+> Despite the ominous phrasing of the source workshop's title ("The End of RSEng?"), the tone of the paper is for the most part optimistic and encouraging of RSEs in and entering the field, and of the value of RSEs within research institutions and beyond.
+
+### Relevance
+
+> Given ECEASST has a focus on software science and technology (including all aspects related to the systematic and rigorous engineering of software and systems), and is intended for the publication of conference proceedings to disseminate current thinking in this space, this paper is highly relevant; it will be of interest to readers at the intersection of software engineering and research in a range of fields.
+
+### Significance
+
+> The views presented in this paper are significant in that they capture recent rapid changes in this landscape (particularly the impact of generative AI), as well as in including timely projections of where this field (and the career trajectories of practitioners) could and should go in the future.
+
+### Technical soundness
+
+> This paper presents the results of a workshop discussion in the form of an opinion piece, but does not appear to give any information about the participants in the workshop, which would have been interesting and might have been a useful framing for this output (in highlighting the areas of expertise and concern of those involved, which would likely have informed and steered any discussions). However, while it would have been of interest to have some details of the participants, it might have presented difficulties around privacy and the flow of the discussion, and may not have added much additional weight to the workshop output, beyond what can be already surmised of the participants based on the title of the conference and the subject of the workshop. The material as presented is still of value without additional information about the participants.
+
+### Quality of presentation
+
+> There are a few cases of less-than-typical use of the English language which are a little distracting, although they do not detract from the message; e.g.:
+>
+> "In Germany, a formal call for creating a sustainable environment for research software is only a couple of years behind" (behind what?); and
+>
+> "While future projections are common in industry [Gar25], so far there is a projection lacking for the RSEng space" (slightly stilted and non-standard English in "a projection lacking").
+>
+> These cases are minor and debatable, and as such do not merit additional editing.
+
+> The use of 'Achieved Goals' boxes to highlight positive future outcomes for the field, and 'Story' boxes to bring the potential changes in the field to a human level with a focus on fictional personas, are nice touches that enhance the readability and impact of this piece.
+
+> Another very minor point: the gender pronouns of the two personas ('Kim' and 'Kay') appear to swap at times; e.g. in Story 3 'Kay' is 'her' and in Story 4 'Kim' is 'him', while in Story 6 'Kay' is 'he' and 'Kim' is 'she')
+
+### Suggestions
+
+> If possible, the inclusion of a small table, figure, and/or a few lines of text summarising the distribution of key features of the workshop participants might be an interesting addition (e.g. level of academic/research education, an indication of their software engineering proficiency/professionalism, their age and/or career stage)... I would be curious as to the level of 'optimism' and expectations for change for the field that participants with different backgrounds might tend to have, although I feel that your paper has merit and interest as it stands, with no such changes needed.
+
+> I am selecting 'Revisions Required' in case you would like to make such an addition (and/or address the other very minor points I made about some cases of slightly non-standard English, and the swapping of genders of your personas), but do not think revisions are strictly necessary; the paper could be published as-is.


### PR DESCRIPTION
Adds a file `correspondence/review-1.md` which includes the review text and a skeleton for the rebuttal.

I would like to get this merged as a skeleton, so that follow-up PRs can comment on each point